### PR TITLE
Automate basic data cleaning

### DIFF
--- a/Application_data_cleaning.ipynb
+++ b/Application_data_cleaning.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import libraries and settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# File system manangement\n",
+    "import os\n",
+    "\n",
+    "# Suppress warnings \n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
+    "# numpy and pandas for data manipulation\n",
+    "import numpy as np\n",
+    "import pandas as pd \n",
+    "\n",
+    "# matplotlib and seaborn for plotting\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "\n",
+    "# import UDF\n",
+    "import basic_application_data_cleaner as cleaner"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Raw application data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "path_to_kaggle_data='~/kaggle_JPFGM/Data/'  # location of all the unzipped data files on local machine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Raw training data shape:  (307511, 122)\n",
+      "Raw testing data shape:  (48744, 121)\n"
+     ]
+    }
+   ],
+   "source": [
+    "app_train, app_test = cleaner.read_raw_application_data(path_to_kaggle_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleaned application data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cleaned training data shape:  (307511, 247)\n",
+      "Cleaned testing data shape:  (48744, 246)\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_train, df_test = cleaner.wrangle_application_train_test_data(app_train, app_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "missing data in cleaned training data set: 0\n",
+      "missing data in cleaned test data set: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('missing data in cleaned training data set:', df_train.isnull().sum().sum())\n",
+    "print('missing data in cleaned test data set:', df_test.isnull().sum().sum())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:anaconda3]",
+   "language": "python",
+   "name": "conda-env-anaconda3-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/basic_application_data_cleaner.py
+++ b/basic_application_data_cleaner.py
@@ -1,0 +1,80 @@
+"""This module performs basic cleaning for the application training and testing data."""
+
+import numpy as np
+import pandas as pd
+
+from sklearn.preprocessing import Imputer
+
+
+def read_raw_application_data(path_to_kaggle_data='~/kaggle_JPFGM/Data/'):
+    """Read in raw csv files of application train and test data."""
+    app_train = pd.read_csv(path_to_kaggle_data + 'application_train.csv')
+    print('Training data shape: ', app_train.shape)
+
+    app_test = pd.read_csv(path_to_kaggle_data + 'application_test.csv')
+    print('Testing data shape: ', app_test.shape)
+    return app_train, app_test
+
+
+def wrangle_application_train_test_data(app_train, app_test):
+    """Wrangle application data for given train and test subset.
+
+    Parameters:
+        app_train: training data, with columns in application_train.csv
+        app_test: testing data, with columns in application_test.csv
+    """
+    df_train = app_train.copy()
+    df_test = app_test.copy()
+
+    """Transformations that are the same for train and test set"""
+    df_train = fix_application_data_anomalies(df_train)
+    df_test = fix_application_data_anomalies(df_test)
+
+    """Impute missing values for numerical columns based on train set"""
+    imputer = Imputer(strategy='median')  # Median after fixing anomalies
+
+    train_num_cols = list(df_train._get_numeric_data().columns)
+    test_num_cols = list(df_test._get_numeric_data().columns)
+
+    df_train[train_num_cols] = imputer.fit_transform(df_train[train_num_cols])
+    df_test[test_num_cols] = imputer.transform(df_test[test_num_cols])
+
+    """Encode categorical attributes based on train set"""
+    df_train = pd.get_dummies(df_train, dummy_na=True, drop_first=True)
+    df_test = pd.get_dummies(df_test, dummy_na=True, drop_first=True)
+
+    # align data frames according to training data
+    train_labels = df_train['TARGET']
+
+    df_train, df_test = df_train.drop('TARGET', axis=1).align(
+        df_test, join='left', fill_value=0, axis=1
+    )  # df_test may have columns full of 0, which is ok for prediction
+
+    # Add the target back in
+    df_train['TARGET'] = train_labels
+    return df_train, df_test
+
+
+def fix_application_data_anomalies(app_data):
+    """Wrangle application data column anomalies.
+
+    Modifies column values and adds and deletes columns, only if it pertains exactly as stated
+    to any subset of training and testing data.
+    """
+    df = app_data.copy()
+
+    """Fix DAYS_EMPLOYED anomalies"""
+    # Create an anomalous flag column
+    df['DAYS_EMPLOYED_ANOM'] = (df["DAYS_EMPLOYED"] == 365243)
+
+    # Replace the anomalous values with nan
+    df['DAYS_EMPLOYED'].replace({365243: np.nan}, inplace=True)
+
+    """make DAYS_BIRTH positive"""
+    df['DAYS_BIRTH'] = abs(df['DAYS_BIRTH'])
+
+    """Impute missing values for categorical columns"""
+    categ_cols = list(df.select_dtypes(include=['object']).columns)
+    df[categ_cols].fillna(value='Unknown', inplace=True)
+
+    return df

--- a/basic_application_data_cleaner.py
+++ b/basic_application_data_cleaner.py
@@ -9,10 +9,10 @@ from sklearn.preprocessing import Imputer
 def read_raw_application_data(path_to_kaggle_data='~/kaggle_JPFGM/Data/'):
     """Read in raw csv files of application train and test data."""
     app_train = pd.read_csv(path_to_kaggle_data + 'application_train.csv')
-    print('Training data shape: ', app_train.shape)
+    print('Raw training data shape: ', app_train.shape)
 
     app_test = pd.read_csv(path_to_kaggle_data + 'application_test.csv')
-    print('Testing data shape: ', app_test.shape)
+    print('Raw testing data shape: ', app_test.shape)
     return app_train, app_test
 
 
@@ -33,7 +33,7 @@ def wrangle_application_train_test_data(app_train, app_test):
     """Impute missing values for numerical columns based on train set"""
     imputer = Imputer(strategy='median')  # Median after fixing anomalies
 
-    train_num_cols = list(df_train._get_numeric_data().columns)
+    train_num_cols = list(df_train.drop('TARGET', axis=1)._get_numeric_data().columns)
     test_num_cols = list(df_test._get_numeric_data().columns)
 
     df_train[train_num_cols] = imputer.fit_transform(df_train[train_num_cols])
@@ -52,6 +52,10 @@ def wrangle_application_train_test_data(app_train, app_test):
 
     # Add the target back in
     df_train['TARGET'] = train_labels
+
+    print('Cleaned training data shape: ', df_train.shape)
+    print('Cleaned testing data shape: ', df_test.shape)
+
     return df_train, df_test
 
 


### PR DESCRIPTION
1. Created a script for basic data cleaning. It is based on the "Start here..." kernel, with slight modifications.
- transforms attributes with anomalies
- imputes missing data. For numerical features, imputes the median of the _training_ data (after fixing anomalies), and uses this to transform the test data. I used python's Imputer class which "remembers" the median automatically.
- Encodes categorical variables as one-hot vectors, considering missing values as its own category "NaN". Eliminates the first category to avoid multicollinearity.
Note that further cleaning and scaling may be necessary, depending on the ML algorithm. This is intended to be built upon.

2. Added a new notebook that shows how to use the script. You can load it in the raw data for exploration, or the processed data for machine learning. Using the function ensures the train/test data is processed in the same way each time you run a model. Note that this only applies to the main application_train and application_test data sets
